### PR TITLE
Character shield access helper

### DIFF
--- a/OsiInterface/GameDefinitions/GameHelpers.cpp
+++ b/OsiInterface/GameDefinitions/GameHelpers.cpp
@@ -941,6 +941,16 @@ namespace dse
 		return offHandWeapon;
 	}
 
+	CDivinityStats_Item * CDivinityStats_Character::GetShield()
+	{
+		auto shield = GetItemBySlot(ItemSlot::Shield, true);
+		if (shield == nullptr || shield->ItemType != EquipmentStatsType::Shield) {
+			return nullptr;
+		}
+
+		return shield
+	}
+
 	bool CDivinityStats_Character::IsBoostActive(uint32_t conditionMask)
 	{
 		return conditionMask == 0

--- a/OsiInterface/GameDefinitions/Stats.h
+++ b/OsiInterface/GameDefinitions/Stats.h
@@ -617,6 +617,7 @@ namespace dse
 		CDivinityStats_Item * GetItemBySlot(ItemSlot slot, bool mustBeEquipped);
 		CDivinityStats_Item * GetMainWeapon();
 		CDivinityStats_Item * GetOffHandWeapon();
+		CDivinityStats_Item * GetShield();
 		int32_t GetPhysicalResistance(bool excludeBoosts);
 		int32_t GetPiercingResistance(bool excludeBoosts);
 		int32_t GetMagicResistance(bool excludeBoosts);

--- a/OsiInterface/Lua/LuaBinding.cpp
+++ b/OsiInterface/Lua/LuaBinding.cpp
@@ -178,6 +178,16 @@ namespace dse::lua
 			}
 		}
 
+		if (prop == GFS.strShield) {
+			auto shield = stats->GetShield();
+			if (shield != nullptr) {
+				ObjectProxy<CDivinityStats_Item::New(L, shield);
+				return 1;
+			}
+			
+			return 0;
+		}
+
 		if (strncmp(propStr, "TALENT_", 7) == 0) {
 			auto talentId = EnumInfo<TalentType>::Find(propStr + 7);
 			if (talentId) {


### PR DESCRIPTION
Implements a helper to get a character's shield from the character's object. I based the implementation basically copying it from offHandWeapon, so I'm not sure if there's any critical implementation lacking to make this impossible :x