### PR TITLE
Improve global debug functions

### DIFF
--- a/ScriptExtender/LuaScripts/BuiltinLibraryClient.lua
+++ b/ScriptExtender/LuaScripts/BuiltinLibraryClient.lua
@@ -254,6 +254,20 @@ _C = function (playerIndex)
 	return Ext.Entity.GetCharacter(charNetID) 
 end
 
+-- Debug helper to get the current player character's weapon
+_W = function ()
+	local char = _C()
+	local item
+
+	if char then
+		local itemGUID = char:GetItemBySlot("Weapon")
+
+		item = itemGUID and Ext.Entity.GetItem(itemGUID)
+	end
+
+	return item
+end
+
 -- Debug helper to get character being examined
 _E = function ()
 	local examine = Ext.UI.GetByType(104)

--- a/ScriptExtender/LuaScripts/BuiltinLibraryClient.lua
+++ b/ScriptExtender/LuaScripts/BuiltinLibraryClient.lua
@@ -245,12 +245,13 @@ Ext.Events.SkillGetPropertyDescription:Subscribe(function (e)
 end)
 
 -- Debug helper to get current player character
-_C = function ()
-	local statusConsole = Ext.UI.GetByType(117)
-	if statusConsole == nil then return end
-	local handle = statusConsole:GetPlayerHandle()
-	if handle == nil then return end
-	return Ext.Entity.GetCharacter(handle)
+_C = function (playerIndex)
+	playerIndex = playerIndex or 1
+	local playerManager = Ext.Entity.GetPlayerManager()
+	local player = playerManager.ClientPlayerData[playerIndex]
+	local charNetID = player and player.CharacterNetId
+	
+	return Ext.Entity.GetCharacter(charNetID) 
 end
 
 -- Debug helper to get character being examined

--- a/ScriptExtender/LuaScripts/Libs/HelpersGenerator/CustomEntries.lua
+++ b/ScriptExtender/LuaScripts/Libs/HelpersGenerator/CustomEntries.lua
@@ -9,6 +9,30 @@ return {
 	Specific = {SubscribableEventType = SubscribableEventType},
 	Misc = {
 [[
+--#region Debug/dev functions
+
+--- Returns the active controlled character.
+--- @param playerIndex integer? Defaults to 1.
+--- @return EclCharacter|EsvCharacter
+function _C(playerIndex) end
+
+--- Returns the character being examined in the examine UI.
+--- Client-only.
+--- @return EclCharacter
+function _E() end
+
+--- Returns the item equipped in the Weapon slot of the active controlled character.
+--- In the client context, this uses player 1's character.
+--- @return EclItem|EsvItem
+function _W() end
+
+-- Aliases for logging functions.
+_D = Ext.Dump
+_DS = Ext.DumpShallow
+_P = Ext.Utils.Print
+
+--#endregion
+
 --#region Deprecated Functions (moved to Ext modules)
 
 --- @deprecated

--- a/ScriptExtender/LuaScripts/Libs/HelpersGenerator/CustomEntries.lua
+++ b/ScriptExtender/LuaScripts/Libs/HelpersGenerator/CustomEntries.lua
@@ -11,16 +11,19 @@ return {
 [[
 --#region Debug/dev functions
 
+--- @deprecated For debugging usage only - do not use in mod releases.
 --- Returns the active controlled character.
 --- @param playerIndex integer? Defaults to 1.
 --- @return EclCharacter|EsvCharacter
 function _C(playerIndex) end
 
+--- @deprecated For debugging usage only - do not use in mod releases.
 --- Returns the character being examined in the examine UI.
 --- Client-only.
 --- @return EclCharacter
 function _E() end
 
+--- @deprecated For debugging usage only - do not use in mod releases.
 --- Returns the item equipped in the Weapon slot of the active controlled character.
 --- In the client context, this uses player 1's character.
 --- @return EclItem|EsvItem


### PR DESCRIPTION
This pull request makes minor improvements to the existing global debug functions:
- `_C()` has been rewritten on the client to use `PlayerManager` and now takes the player index as an optional parameter, allowing it to be used to fetch the player 2's character in local co-op. In addition it now works while in the controller UI (which it previously didn't as it relied on KB+M UIs)
- `_W()` has been implemented on the client, returning the `EclItem` equipped
- All these global functions (`_C`, `_W`, `_E`, `_P`, `_D`, `_DS`) have been added to the IDE helpers. They are marked with `@deprecated` so as to trigger an IDE warning with a message stating they should not be left in mod releases. One could argue that these functions should not be present in the IDE helpers - but I thought it would offer users a way to learn about them that doesn't involve browsing the source code.

![image](https://user-images.githubusercontent.com/53646914/196250746-e19d08f4-fb65-4143-9505-0e37c831465b.png)

Note: I have not actually tested using `_C(2)` to fetch player 2's character as I currently do not have a second controller to test splitscreen stuff. It should work if player 2's index in the `PlayerManager` is 2.
