### PR TITLE
Add setting to default to client console context

### DIFF
--- a/ScriptExtender/Extender/Shared/Console.cpp
+++ b/ScriptExtender/Extender/Shared/Console.cpp
@@ -303,6 +303,7 @@ void DebugConsole::Create()
 	FILE* inputStream;
 	freopen_s(&inputStream, "CONIN$", "r", stdin);
 	consoleRunning_ = true;
+	serverContext_ = !gExtender->GetConfig().DefaultToClientConsole;
 
 	DEBUG("******************************************************************************");
 	DEBUG("*                                                                            *");

--- a/ScriptExtender/Extender/Shared/ExtenderConfig.h
+++ b/ScriptExtender/Extender/Shared/ExtenderConfig.h
@@ -12,6 +12,7 @@ struct ExtenderConfig
 	bool EnableLuaDebugger{ false };
 #else
 	bool CreateConsole{ true };
+	bool DefaultToClientConsole{ false };
 	bool EnableDebugger{ true };
 	bool EnableLuaDebugger{ true };
 #endif

--- a/ScriptExtender/dllmain.cpp
+++ b/ScriptExtender/dllmain.cpp
@@ -52,6 +52,7 @@ void LoadConfig(std::wstring const & configPath, dse::ExtenderConfig & config)
 	}
 
 	ConfigGet(root, "CreateConsole", config.CreateConsole);
+	ConfigGet(root, "DefaultToClientConsole", config.DefaultToClientConsole);
 	ConfigGet(root, "EnableLogging", config.EnableLogging);
 	ConfigGet(root, "LogCompile", config.LogCompile);
 	ConfigGet(root, "LogFailedCompile", config.LogFailedCompile);


### PR DESCRIPTION
This pull request adds a new `DefaultToClientConsole` setting to `OsirisExtenderSettings.json` that allows the user to set the console to use the client context upon startup.

The default value of the setting is `false`, making the console start in the server context, meaning the default behaviour is unchanged.