### PR TITLE
Fix for treasure tables chance

### DIFF
--- a/ScriptExtender/Lua/Shared/LuaSerializers.cpp
+++ b/ScriptExtender/Lua/Shared/LuaSerializers.cpp
@@ -117,7 +117,7 @@ namespace dse::lua
 			if (v.DropCounts.size() > 0 || v.TotalCount > 0) {
 				v.TotalCount = 0;
 				for (uint32_t i = 0; i < v.DropCounts.size(); i++) {
-					v.TotalCount += v.DropCounts[i].Amount;
+					v.TotalCount += v.DropCounts[i].Chance;
 				}
 			}
 


### PR DESCRIPTION
When you update them, the loot instantly drops, as if the drop rate is set to 1:1, and only after that the treasure table works normally with its real chances. I noticed that the "TotalCount" parameter is updated illogically: the first time it calculates the sum of the "Amount" parameters in "DropCounts", the second time it sums the "Chance" parameters