### PR TITLE
Fix for unmapped stat ids not being passed to callbacks for examine ui

### DIFF
--- a/ScriptExtender/LuaScripts/Libs/Game.Tooltip.RequestProcessor.lua
+++ b/ScriptExtender/LuaScripts/Libs/Game.Tooltip.RequestProcessor.lua
@@ -618,7 +618,7 @@ function RequestProcessor.OnExamineTooltip(e, ui, event, typeIndex, id, ...)
 
 	if typeIndex == 1 then
 		request.Type = "Stat"
-		request.Stat = Game.Tooltip.TooltipStatAttributes[id]
+		request.Stat = Game.Tooltip.TooltipStatAttributes[id] or id
 
 		if request.Stat == nil then
 			_PrintWarning("Requested tooltip for unknown stat ID " .. id)


### PR DESCRIPTION
Looks like a small oversight as unmapped ids are passed when the request is from characterSheet.