### PR TITLE
Add console clear command and "clear on reset" setting

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,3 +33,5 @@ The following configuration variables can be set in the `OsirisExtenderSettings.
 | DebuggerPort | Integer | Port number the Osiris debugger will listen on (default 9999) |
 | EnableLuaDebugger | Boolean | Enables the Lua debugger interface |
 | LuaDebuggerPort | Integer | Port number the Lua debugger will listen on (default 9998) |
+| DefaultToClientConsole | Boolean | Makes the console default to the client context instead of server. Defaults to `false`.
+| ClearOnReset | Boolean | Clears the console window upon a manual Lua reset. Defaults to `false`.

--- a/ScriptExtender/Extender/Shared/Console.cpp
+++ b/ScriptExtender/Extender/Shared/Console.cpp
@@ -127,12 +127,30 @@ void DebugConsole::PrintHelp()
 	DEBUG("  reset server - Reset server Lua state");
 	DEBUG("  reset - Reset client and server Lua states");
 	DEBUG("  silence <on|off> - Enable/disable silent mode (log output when in input mode)");
+	DEBUG("  clear - Clear the console");
 	DEBUG("  exit - Leave console mode");
 	DEBUG("  !<cmd> <arg1> ... <argN> - Trigger Lua \"ConsoleCommand\" event with arguments cmd, arg1, ..., argN");
 }
 
+void DebugConsole::Clear()
+{
+	// Clear screen, move cursor to top-left and clear scrollback
+	std::cout << "\x1b[2J" "\x1b[H" "\x1b[3J";
+}
+
+void DebugConsole::ClearFromReset()
+{
+	// Clear console if the setting is enabled
+	if (gExtender->GetConfig().ClearOnReset)
+	{
+		gConsole.Clear();
+	}
+}
+
 void DebugConsole::ResetLua()
 {
+	ClearFromReset();
+
 	DEBUG("Resetting Lua states.");
 	SubmitTaskAndWait(true, []() {
 		gExtender->GetServer().ResetLuaState();
@@ -147,6 +165,8 @@ void DebugConsole::ResetLua()
 
 void DebugConsole::ResetLuaClient()
 {
+	ClearFromReset();
+
 	DEBUG("Resetting client Lua state.");
 	SubmitTaskAndWait(false, []() {
 		if (!gExtender->GetServer().RequestResetClientLuaState()) {
@@ -157,6 +177,8 @@ void DebugConsole::ResetLuaClient()
 
 void DebugConsole::ResetLuaServer()
 {
+	ClearFromReset();
+
 	DEBUG("Resetting server Lua state.");
 	SubmitTaskAndWait(true, []() {
 		gExtender->GetServer().ResetLuaState();
@@ -217,6 +239,8 @@ void DebugConsole::HandleCommand(std::string const& cmd)
 	} else if (cmd == "silence off") {
 		DEBUG("Silent mode OFF");
 		silence_ = false;
+	} else if (cmd == "clear") {
+		Clear();
 	} else if (cmd == "help") {
 		PrintHelp();
 	} else {

--- a/ScriptExtender/Extender/Shared/Console.h
+++ b/ScriptExtender/Extender/Shared/Console.h
@@ -17,6 +17,8 @@ public:
 
 	void HandleCommand(std::string const& cmd);
 
+	void Clear();
+
 private:
 	bool created_{ false };
 	bool inputEnabled_{ false };
@@ -37,6 +39,7 @@ private:
 	void ResetLuaClient();
 	void ResetLuaServer();
 	void ExecLuaCommand(std::string const& cmd);
+	void ClearFromReset();
 };
 
 extern DebugConsole gConsole;

--- a/ScriptExtender/Extender/Shared/ExtenderConfig.h
+++ b/ScriptExtender/Extender/Shared/ExtenderConfig.h
@@ -30,6 +30,7 @@ struct ExtenderConfig
 	bool SendCrashReports{ true };
 	bool ForceCrashReporting{ false };
 	bool EnableAchievements{ true };
+	bool ClearOnReset{ false };
 
 	bool OptimizeHashing{ true };
 #if defined(OSI_EXTENSION_BUILD)

--- a/ScriptExtender/dllmain.cpp
+++ b/ScriptExtender/dllmain.cpp
@@ -69,6 +69,7 @@ void LoadConfig(std::wstring const & configPath, dse::ExtenderConfig & config)
 	ConfigGet(root, "DeveloperMode", config.DeveloperMode);
 	ConfigGet(root, "ShowPerfWarnings", config.ShowPerfWarnings);
 	ConfigGet(root, "EnableAchievements", config.EnableAchievements);
+	ConfigGet(root, "ClearOnReset", config.ClearOnReset);
 
 	ConfigGet(root, "DebuggerPort", config.DebuggerPort);
 	ConfigGet(root, "LuaDebuggerPort", config.LuaDebuggerPort);


### PR DESCRIPTION
This PR adds a `clear` command to the console that clears the console, to remove clutter logging from previous Lua states.

![image](https://github.com/Norbyte/ositools/assets/53646914/17008a20-7da3-4b26-a649-20a4bef03e9e)
^ Console state after clearing. Scrollback is cleared as well.

Additionally, a `ClearOnReset` setting has been added which clears the console anytime `reset`, `reset client` or `reset server` are *manually* executed from the console. This clearing happens right before the "Resetting Lua states" message. This setting is off by default - default behaviour is unmodified.

Though it's possible to clear the console from user code, it is unreliable as messages about any scripts loaded before yours will be cleared out, possibly causing the user to miss errors during bootstrap.

The readme has been updated with this setting and the previous one I added (didn't see a need to make a separate PR for that, but feel free to disagree). The `help` command also mentions the `clear` command, which will work regardless of the previously mentioned setting.