### PR TITLE
Expand Ext.IO

### DIFF
--- a/ScriptExtender/Lua/Libs/IO.inl
+++ b/ScriptExtender/Lua/Libs/IO.inl
@@ -11,6 +11,16 @@ ObjectSet<FixedString> Enumerate(std::optional<STDString> path)
 	return script::EnumerateDirectory(path.value_or(""), PathRootType::GameStorage);
 }
 
+bool IsFile(char const* path)
+{
+	return script::IsFile(path, PathRootType::GameStorage);
+}
+
+bool IsDirectory(char const* path)
+{
+	return script::IsDirectory(path, PathRootType::GameStorage);
+}
+
 std::optional<STDString> LoadFile(char const* path, std::optional<FixedString> context)
 {
 	if (!context || *context == GFS.struser) {
@@ -43,6 +53,8 @@ void RegisterIOLib()
 	DECLARE_MODULE(IO, Both)
 	BEGIN_MODULE()
 	MODULE_FUNCTION(Enumerate)
+	MODULE_FUNCTION(IsFile)
+	MODULE_FUNCTION(IsDirectory)
 	MODULE_FUNCTION(LoadFile)
 	MODULE_FUNCTION(SaveFile)
 	MODULE_FUNCTION(AddPathOverride)

--- a/ScriptExtender/Lua/Libs/IO.inl
+++ b/ScriptExtender/Lua/Libs/IO.inl
@@ -6,6 +6,11 @@
 /// <lua_module>IO</lua_module>
 BEGIN_NS(lua::io)
 
+ObjectSet<FixedString> Enumerate(std::optional<STDString> path)
+{
+	return script::EnumerateDirectory(path.value_or(""), PathRootType::GameStorage);
+}
+
 std::optional<STDString> LoadFile(char const* path, std::optional<FixedString> context)
 {
 	if (!context || *context == GFS.struser) {
@@ -37,6 +42,7 @@ void RegisterIOLib()
 {
 	DECLARE_MODULE(IO, Both)
 	BEGIN_MODULE()
+	MODULE_FUNCTION(Enumerate)
 	MODULE_FUNCTION(LoadFile)
 	MODULE_FUNCTION(SaveFile)
 	MODULE_FUNCTION(AddPathOverride)

--- a/ScriptExtender/ScriptHelpers.cpp
+++ b/ScriptExtender/ScriptHelpers.cpp
@@ -69,6 +69,33 @@ ObjectSet<FixedString> EnumerateDirectory(std::string_view directoryPath, PathRo
 	return paths;
 }
 
+bool IsFile(std::string_view path, PathRootType root)
+{
+	if (root == PathRootType::GameStorage) {
+		auto absolutePath = GetPathForExternalIo(path, PathRootType::GameStorage);
+		if (!absolutePath) return false;
+
+		return std::filesystem::is_regular_file(absolutePath.value());
+	} else {
+		LuaError("Unsupported file context");
+		return false;
+	}
+}
+
+bool IsDirectory(std::string_view path, PathRootType root)
+{
+	if (root == PathRootType::GameStorage) {
+		auto absolutePath = GetPathForExternalIo(path, PathRootType::GameStorage);
+		if (!absolutePath) return false;
+
+		return std::filesystem::is_directory(absolutePath.value());
+	}
+	else {
+		LuaError("Unsupported file context");
+		return false;
+	}
+}
+
 std::optional<STDString> LoadExternalFile(std::string_view path, PathRootType root)
 {
 	if (!IsSafeRelativePath(STDString(path))) {

--- a/ScriptExtender/ScriptHelpers.cpp
+++ b/ScriptExtender/ScriptHelpers.cpp
@@ -134,10 +134,9 @@ bool SaveExternalFile(std::string_view path, PathRootType root, std::string_view
 	if (dirEnd == std::string::npos) return false;
 
 	auto storageDir = absolutePath->substr(0, dirEnd);
-	BOOL created = CreateDirectoryW(storageDir.c_str(), NULL);
-	if (created == FALSE) {
-		DWORD lastError = GetLastError();
-		if (lastError != ERROR_ALREADY_EXISTS) {
+	if (!std::filesystem::exists(storageDir) || !std::filesystem::is_directory(storageDir)) {
+		bool created = std::filesystem::create_directories(storageDir);
+		if (!created) {
 			OsiError("Could not create storage directory: " << ToUTF8(storageDir));
 			return {};
 		}

--- a/ScriptExtender/ScriptHelpers.h
+++ b/ScriptExtender/ScriptHelpers.h
@@ -6,6 +6,7 @@
 namespace dse::script {
 
 	std::optional<STDWString> GetPathForExternalIo(std::string_view scriptPath, PathRootType root);
+	ObjectSet<FixedString> EnumerateDirectory(std::string_view directoryPath, PathRootType root);
 	std::optional<STDString> LoadExternalFile(std::string_view path, PathRootType root);
 	bool SaveExternalFile(std::string_view path, PathRootType root, std::string_view contents);
 

--- a/ScriptExtender/ScriptHelpers.h
+++ b/ScriptExtender/ScriptHelpers.h
@@ -7,6 +7,8 @@ namespace dse::script {
 
 	std::optional<STDWString> GetPathForExternalIo(std::string_view scriptPath, PathRootType root);
 	ObjectSet<FixedString> EnumerateDirectory(std::string_view directoryPath, PathRootType root);
+	bool IsFile(std::string_view path, PathRootType root);
+	bool IsDirectory(std::string_view path, PathRootType root);
 	std::optional<STDString> LoadExternalFile(std::string_view path, PathRootType root);
 	bool SaveExternalFile(std::string_view path, PathRootType root, std::string_view contents);
 


### PR DESCRIPTION
This PR adds various new functions to `Ext.IO` as well as a fix to an issue in its `SaveFile()` function.
The new functions support `GameStorage` paths only.

## Enumerate()
`ObjectSet<FixedString> Enumerate(std::optional<STDString> path)`
Lists the directories and files relative to the path. If `path` is not provided, it defaults to the root of `Osiris Data` (equivalent to passing an empty string).
If the path is invalid, returns an empty list.
![image](https://github.com/Norbyte/ositools/assets/53646914/955b0273-b1b2-403f-a47b-1ec841b50ecd)

## IsFile() & IsDirectory()
`bool IsFile(char const* path)`
`bool IsDirectory(char const* path)`
Returns whether the path passed is a regular file or directory, respectively. Returns `false` in the case of invalid/non-existent paths.
![image](https://github.com/Norbyte/ositools/assets/53646914/fc55bdfe-6d52-4a57-a97f-22c55b796dcb)

## SaveFile() fix
This PR fixes not being able to save a file with `SaveFile()` if it involved creating more than one directory along the path. For example, `Ext.IO.SaveFile("A/B/MyFile.json")` would previously fail if directory `A` didn't exist as `CreateDirectoryW()` can only create at most one directory.
