### PR TITLE
Warn when invoking an unregistered console command

### DIFF
--- a/ScriptExtender/LuaScripts/Libs/Event.lua
+++ b/ScriptExtender/LuaScripts/Libs/Event.lua
@@ -490,13 +490,15 @@ _I.DoConsoleCommand = function (cmd)
 	end
 
 	local listeners = _I._ConsoleCommandListeners[params[1]]
-	if listeners ~= nil then
-		for i,callback in pairs(listeners) do
+	if listeners ~= nil and listeners[1] then
+		for _,callback in ipairs(listeners) do
 			local status, result = xpcall(callback, debug.traceback, table.unpack(params))
 			if not status then
 				Ext.PrintError("Error during console command callback: ", result)
 			end
 		end
+	else
+		Ext.PrintError("Unregistered console command:", params[1])
 	end
 end
 


### PR DESCRIPTION
This PR adjusts console commands to show a warning when invoking a command that hasn't been registered.

![image](https://github.com/Norbyte/ositools/assets/53646914/315f5f4b-c9ea-430a-8253-cde07de76947)

This makes it easier/faster to realize whether you've made a typo in a command, forgot to load the script it's in, are trying to run it in the wrong context, or ran into other shenanigans that might cause it to not run.

The loop has also been adjusted to use `ipairs()`; [the order of `pairs()` is unspecified for numeric keys](https://www.lua.org/manual/5.4/manual.html#pdf-next), though it does seem to work orderly in most cases.

Additionally, the `i` variable in the loop has been replaced with `_` to silence an "unused variable" warning in the Sumneko lua extension.