### PR TITLE
Fix "Entering console" message not considering the existence of client guys

### DIFF
--- a/ScriptExtender/Extender/Shared/Console.cpp
+++ b/ScriptExtender/Extender/Shared/Console.cpp
@@ -260,7 +260,8 @@ void DebugConsole::ConsoleThread()
 			continue;
 		}
 
-		DEBUG("Entering server Lua console.");
+		std::string message = "Entering " + std::string(serverContext_ ? "server" : "client") + " Lua console.";
+		DEBUG(&message[0]);
 
 		while (consoleRunning_) {
 			inputEnabled_ = true;


### PR DESCRIPTION
This PR fixes the message upon entering the console always saying "Entering server Lua console" even if the last context was client.

![image](https://github.com/Norbyte/ositools/assets/53646914/3354e5c7-592d-4f00-96be-24d0f90e4d3e)
